### PR TITLE
Adding tests for certain failing tag scenarios

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -37,6 +37,12 @@ namespace :test do
     t.verbose    = true
   end
 
+  Rake::TestTask.new('core:tag') do |t|
+    t.libs << BASE_DIR
+    t.test_files = FileList["#{BASE_DIR}/core/test_tag.rb"]
+    t.verbose    = true
+  end
+
   Rake::TestTask.new('plugins:killbill-invoice-test') do |t|
     t.libs << BASE_DIR
     t.test_files = FileList["#{BASE_DIR}/plugins/killbill-invoice-test/test_*.rb"]

--- a/killbill-integration-tests/core/test_tag.rb
+++ b/killbill-integration-tests/core/test_tag.rb
@@ -1,0 +1,43 @@
+$LOAD_PATH.unshift File.expand_path('../..', __FILE__)
+
+require 'test_base'
+require 'pp'
+
+module KillBillIntegrationTests
+
+  class TestTag < Base
+
+    def setup
+      setup_base
+
+      @account = create_account(@user, @options)
+      add_payment_method(@account.account_id, '__EXTERNAL_PAYMENT__', true, nil, @user, @options)
+      @account = get_account(@account.account_id, false, false, @options)
+    end
+
+    def teardown
+      teardown_base
+    end
+
+    def test_auto_pay_off
+      @account.set_auto_pay_off(@user, nil, nil, @options)
+      assert_true @account.auto_pay_off?(@options)
+      @account.remove_auto_pay_off(@user, nil, nil, @options)
+      assert_false @account.auto_pay_off?(@options)
+    end
+
+    def test_set_tags
+      @account.add_tag('TEST', @user, nil, nil, @options)
+      assert_true @account.control_tag?(KillBillClient::Model::TagHelper::TEST_ID, @options)
+      assert_false @account.control_tag?(KillBillClient::Model::TagHelper::AUTO_PAY_OFF_ID, @options)
+      assert_false @account.control_tag?(KillBillClient::Model::TagHelper::WRITTEN_OFF_ID, @options)
+      @account.set_tags([
+        KillBillClient::Model::TagHelper::AUTO_PAY_OFF_ID,
+        KillBillClient::Model::TagHelper::WRITTEN_OFF_ID
+      ], @user, nil, nil, @options)
+      assert_false @account.test?(@options)
+      assert_true @account.auto_pay_off?(@options)
+      assert_true @account.written_off?(@options)
+    end
+  end
+end


### PR DESCRIPTION
These tests should be fixed by the following pull requests in the https://github.com/killbill/killbill-client-ruby repo:
- https://github.com/killbill/killbill-client-ruby/pull/12
- https://github.com/killbill/killbill-client-ruby/pull/13
- https://github.com/killbill/killbill-client-ruby/pull/14
