### PR TITLE
Test invoice payment chargerback reservals

### DIFF
--- a/killbill-integration-tests/core/test_account.rb
+++ b/killbill-integration-tests/core/test_account.rb
@@ -132,5 +132,54 @@ module KillBillIntegrationTests
 
     end
 
+    def test_emails_notifications
+
+      account = create_account(@user, @options)
+
+      # Verify if response is success
+      assert(account.email_notifications(@options).response.kind_of? Net::HTTPSuccess)
+
+    end
+
+    def test_account_blocking_state
+
+      account = create_account(@user, @options)
+
+      # Verify account methods
+      assert_respond_to(account, :blocking_states)
+      assert_respond_to(account, :set_blocking_state)
+
+      # Get blocking states
+      blocking_states = account.blocking_states('ACCOUNT', nil, 'NONE', @options)
+
+      # Verify if the returned list is empty
+      assert(blocking_states.empty?)
+
+      # Verify if response is success
+      assert(account.set_blocking_state('STATE1', 'ServiceStateService', false, false, false, nil, @user, nil, nil, @options).response .kind_of? Net::HTTPSuccess)
+
+      # Verify if the returned list has now one element
+      blocking_states = account.blocking_states('ACCOUNT', nil, 'NONE', @options)
+      assert_equal(1, blocking_states.size)
+
+      # Verify blocking state fields
+      blocking_states = blocking_states.first
+      assert_equal('STATE1', blocking_states.state_name)
+      assert_equal('ServiceStateService', blocking_states.service)
+      assert_false(blocking_states.block_change)
+      assert_false(blocking_states.block_entitlement)
+      assert_false(blocking_states.block_billing)
+
+    end
+
+    def test_cba_rebalancing
+
+      account = create_account(@user, @options)
+
+      # Verify if response is success
+      assert(account.cba_rebalancing(@user, nil, nil, @options).response.kind_of? Net::HTTPSuccess)
+
+    end
+
   end
 end

--- a/killbill-integration-tests/core/test_invoice_payment.rb
+++ b/killbill-integration-tests/core/test_invoice_payment.rb
@@ -154,40 +154,5 @@ module KillBillIntegrationTests
       assert_equal(-50.0, invoice.refund_adj)
     end
 
-    def test_create_chargeback_and_chargeback_reversal
-
-      # Create a charge to account
-      create_charge(@account.account_id, '50.0', 'USD', 'My charge', @user, @options)
-
-      # Create a payment
-      pay_all_unpaid_invoices(@account.account_id, true, '50.0', @user, @options)
-
-      account = get_account(@account.account_id, true, true, @options)
-      payment_id = account.payments(@options).first.payment_id
-
-      # Verify if a new transaction is created and if their type is PURCHASE
-      account_transactions = account.payments(@options).first.transactions
-      assert_equal(1, account_transactions.size)
-      assert_equal('PURCHASE', account_transactions[0].transaction_type)
-
-      # Trigger chargerback
-      chargeback = KillBillClient::Model::InvoicePayment.create_chargeback(payment_id, '50.0', 'USD', nil, @user, nil, nil, @options)
-
-      # Verify if a new transaction is created and if their type is CHARGEBACK
-      account_transactions = account.payments(@options).first.transactions
-      assert_equal(2, account_transactions.size)
-      assert_equal('CHARGEBACK', account_transactions[1].transaction_type)
-
-      # Trigger chargerback reversal
-      transaction_external_key = chargeback.transactions[1].transaction_external_key
-      KillBillClient::Model::InvoicePayment.chargeback_reversal(payment_id, transaction_external_key, nil, @user, nil, nil, @options)
-
-      # Verify if a new transaction is created and if their type is CHARGEBACK
-      account_transactions = account.payments(@options).first.transactions
-      assert_equal(3, account_transactions.size)
-      assert_equal('CHARGEBACK', account_transactions[2].transaction_type)
-
-    end
-
   end
 end

--- a/killbill-integration-tests/core/test_invoice_payment.rb
+++ b/killbill-integration-tests/core/test_invoice_payment.rb
@@ -184,6 +184,7 @@ module KillBillIntegrationTests
       account_transactions = account.payments(@options).first.transactions
       assert_equal(1, account_transactions.size)
       assert_equal('PURCHASE', account_transactions[0].transaction_type)
+      assert_equal(0, get_account(@account.account_id, true, true, @options).account_balance)
 
       # Trigger chargerback
       chargeback = KillBillClient::Model::InvoicePayment.create_chargeback(payment_id, '50.0', 'USD', nil, @user, nil, nil, @options)
@@ -192,6 +193,8 @@ module KillBillIntegrationTests
       account_transactions = account.payments(@options).first.transactions
       assert_equal(2, account_transactions.size)
       assert_equal('CHARGEBACK', account_transactions[1].transaction_type)
+      assert_equal(50, get_account(@account.account_id, true, true, @options).account_balance)
+      assert_equal('SUCCESS', account_transactions[1].status)
 
       # Trigger chargerback reversal
       transaction_external_key = chargeback.transactions[1].transaction_external_key
@@ -201,6 +204,8 @@ module KillBillIntegrationTests
       account_transactions = account.payments(@options).first.transactions
       assert_equal(3, account_transactions.size)
       assert_equal('CHARGEBACK', account_transactions[2].transaction_type)
+      assert_equal(0, get_account(@account.account_id, true, true, @options).account_balance)
+      assert_equal('PAYMENT_FAILURE', account_transactions[2].status)
 
     end
 

--- a/killbill-integration-tests/core/test_invoice_payment.rb
+++ b/killbill-integration-tests/core/test_invoice_payment.rb
@@ -154,5 +154,19 @@ module KillBillIntegrationTests
       assert_equal(-50.0, invoice.refund_adj)
     end
 
+    def test_chargeback_reversals
+
+      create_charge(@account.account_id, '50.0', 'USD', 'My charge', @user, @options)
+
+      pay_all_unpaid_invoices(@account.account_id, true, '50.0', @user, @options)
+
+      account = get_account(@account.account_id, true, true, @options)
+      payment_id = account.payments(@options).first.payment_id
+
+      invoice_payment = KillBillClient::Model::InvoicePayment.new
+      puts invoice_payment.chargeback_reversal(payment_id, '50.0', nil, @user, nil, nil, @options)
+
+    end
+
   end
 end

--- a/killbill-integration-tests/core/test_invoice_payment.rb
+++ b/killbill-integration-tests/core/test_invoice_payment.rb
@@ -154,17 +154,38 @@ module KillBillIntegrationTests
       assert_equal(-50.0, invoice.refund_adj)
     end
 
-    def test_chargeback_reversals
+    def test_create_chargeback_and_chargeback_reversal
 
+      # Create a charge to account
       create_charge(@account.account_id, '50.0', 'USD', 'My charge', @user, @options)
 
+      # Create a payment
       pay_all_unpaid_invoices(@account.account_id, true, '50.0', @user, @options)
 
       account = get_account(@account.account_id, true, true, @options)
       payment_id = account.payments(@options).first.payment_id
 
-      invoice_payment = KillBillClient::Model::InvoicePayment.new
-      puts invoice_payment.chargeback_reversal(payment_id, '50.0', nil, @user, nil, nil, @options)
+      # Verify if a new transaction is created and if their type is PURCHASE
+      account_transactions = account.payments(@options).first.transactions
+      assert_equal(1, account_transactions.size)
+      assert_equal('PURCHASE', account_transactions[0].transaction_type)
+
+      # Trigger chargerback
+      chargeback = KillBillClient::Model::InvoicePayment.create_chargeback(payment_id, '50.0', 'USD', nil, @user, nil, nil, @options)
+
+      # Verify if a new transaction is created and if their type is CHARGEBACK
+      account_transactions = account.payments(@options).first.transactions
+      assert_equal(2, account_transactions.size)
+      assert_equal('CHARGEBACK', account_transactions[1].transaction_type)
+
+      # Trigger chargerback reversal
+      transaction_external_key = chargeback.transactions[1].transaction_external_key
+      KillBillClient::Model::InvoicePayment.chargeback_reversal(payment_id, transaction_external_key, nil, @user, nil, nil, @options)
+
+      # Verify if a new transaction is created and if their type is CHARGEBACK
+      account_transactions = account.payments(@options).first.transactions
+      assert_equal(3, account_transactions.size)
+      assert_equal('CHARGEBACK', account_transactions[2].transaction_type)
 
     end
 


### PR DESCRIPTION
I submit this PR for review in that specific endpoint because I need help to understand better how chargerback reservals works. I don't write assertions yet in the test because I'm always recieve a BadRequest:

` KillBillClient::API::BadRequest: {"className":"com.fasterxml.jackson.databind.JsonMappingException","code":null,"message":"Can not instantiate value of type [simple type, class org.killbill.billing.jaxrs.json.InvoicePaymentTransactionJson] from String value ('KillBillClient::Model::InvoicePayment'); no single-String constructor/factory method\n at [Source: org.apache.catalina.connector.CoyoteInputStream@7f233e5; line: 1, column: 1]","causeClassName":null,"causeMessage":null,"stackTrace":[]}
`

Or:


`KillBillClient::API::BadRequest: {"className":"java.lang.IllegalArgumentException","code":null,"message":"transactionExternalKey amount needs to be set","causeClassName":null,"causeMessage":null,"stackTrace":[]}`
