### PR TITLE
Initial tests for changing between recurring in advance and usage in arrear plans

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
     <<: *defaults
     docker:
       - image: killbill/kbbuild:0.5.0
-      - image: killbill/killbill:0.19.19
+      - image: killbill/killbill:0.20.4
         environment:
         - KILLBILL_CATALOG_URI=SpyCarAdvanced.xml
         - KILLBILL_PAYMENT_PLUGIN_TIMEOUT=5s
@@ -40,7 +40,7 @@ jobs:
         - KILLBILL_SERVER_TEST_MODE=true
         - KILLBILL_INVOICE_SANITY_SAFETY_BOUND_ENABLED=false
         - KILLBILL_INVOICE_MAX_DAILY_NUMBER_OF_ITEMS_SAFETY_BOUND=-1
-      - image: killbill/mariadb:0.19
+      - image: killbill/mariadb:0.20
         environment:
         - MYSQL_ROOT_PASSWORD=root
     steps:
@@ -104,7 +104,7 @@ jobs:
     <<: *defaults
     docker:
       - image: killbill/kbbuild:0.5.0
-      - image: killbill/killbill:0.19.19
+      - image: killbill/killbill:0.20.4
         environment:
         - KILLBILL_CATALOG_URI=SpyCarAdvanced.xml
         - KILLBILL_PAYMENT_PLUGIN_TIMEOUT=5s
@@ -114,7 +114,7 @@ jobs:
         - KILLBILL_SERVER_TEST_MODE=true
         - KILLBILL_INVOICE_SANITY_SAFETY_BOUND_ENABLED=false
         - KILLBILL_INVOICE_MAX_DAILY_NUMBER_OF_ITEMS_SAFETY_BOUND=-1
-      - image: killbill/postgresql:0.19
+      - image: killbill/postgresql:0.20
         environment:
         - POSTGRES_PASSWORD=postgres
     steps:

--- a/killbill-integration-tests/core/README.md
+++ b/killbill-integration-tests/core/README.md
@@ -4,6 +4,7 @@
 
 * [test_catalog.rb](test_catalog.rb): Advanced catalogs tests (alignments, price change, grandfathering, etc.).
 * [test_mixed_catalog.rb](test_mixed_catalog.rb): Tests with catalog mixing in advance and in arrear recurring plans. See [Catalog-Mixed.xml](https://github.com/killbill/killbill-integration-tests/tree/master/killbill-integration-tests/resources/Catalog-Mixed.xml).
+* [test_mixed_catalog_with_usage.rb](test_mixed_catalog_with_usage.rb): Tests with catalog mixing in advance recurring plans and in arrear usage plans. See [Catalog-Mixed-With-Usage.xml](https://github.com/killbill/killbill-integration-tests/tree/master/killbill-integration-tests/resources/Catalog-Mixed-With-Usage.xml).
 * [test_recurring_in_arrear.rb](test_recurring_in_arrear.rb): Tests for in arrear recurring plans. See [newspaper.xml](https://github.com/killbill/killbill-integration-tests/tree/master/killbill-integration-tests/resources/newspaper.xml).
 * [usage/test_capacity.rb](usage/test_capacity.rb): Tests for capacity in arrear usage plans. See [Capacity.xml](https://github.com/killbill/killbill-integration-tests/tree/master/killbill-integration-tests/resources/usage/Capacity.xml).
 * [usage/test_cloud.rb](usage/test_cloud.rb): Demo how to use the usage APIs. See [Cloud.xml](https://github.com/killbill/killbill-integration-tests/tree/master/killbill-integration-tests/resources/usage/Cloud.xml).

--- a/killbill-integration-tests/core/README.md
+++ b/killbill-integration-tests/core/README.md
@@ -1,0 +1,12 @@
+# Tests overview
+
+## Catalog
+
+* [test_catalog.rb](test_catalog.rb): Advanced catalogs tests (alignments, price change, grandfathering, etc.).
+* [test_mixed_catalog.rb](test_mixed_catalog.rb): Tests with catalog mixing in advance and in arrear recurring plans. See [Catalog-Mixed.xml](https://github.com/killbill/killbill-integration-tests/tree/master/killbill-integration-tests/resources/Catalog-Mixed.xml).
+* [test_recurring_in_arrear.rb](test_recurring_in_arrear.rb): Tests for in arrear recurring plans. See [newspaper.xml](https://github.com/killbill/killbill-integration-tests/tree/master/killbill-integration-tests/resources/newspaper.xml).
+* [usage/test_capacity.rb](usage/test_capacity.rb): Tests for capacity in arrear usage plans. See [Capacity.xml](https://github.com/killbill/killbill-integration-tests/tree/master/killbill-integration-tests/resources/usage/Capacity.xml).
+* [usage/test_cloud.rb](usage/test_cloud.rb): Demo how to use the usage APIs. See [Cloud.xml](https://github.com/killbill/killbill-integration-tests/tree/master/killbill-integration-tests/resources/usage/Cloud.xml).
+* [usage/test_cloud_detail_mode.rb](usage/test_cloud_detail_mode.rb): Usage tests for invoice modes. See [Cloud.xml](https://github.com/killbill/killbill-integration-tests/tree/master/killbill-integration-tests/resources/usage/Cloud.xml).
+* [usage/test_consumable_top_tier.rb](usage/test_cloud_detail_mode.rb): Tests for consumable in arrear usage plans (top tier). See [ConsumableTopTierPolicy.xml](https://github.com/killbill/killbill-integration-tests/tree/master/killbill-integration-tests/resources/usage/ConsumableTopTierPolicy.xml).
+* [usage/test_default_catalog_consumable_in_arrear.rb](usage/test_default_catalog_consumable_in_arrear.rb): Advanced tests for consumable in arrear usage plans.

--- a/killbill-integration-tests/core/test_mixed_catalog_with_usage.rb
+++ b/killbill-integration-tests/core/test_mixed_catalog_with_usage.rb
@@ -1,0 +1,225 @@
+$LOAD_PATH.unshift File.expand_path('../..', __FILE__)
+
+require 'date'
+
+require 'test_base'
+
+module KillBillIntegrationTests
+
+  class TestMixedCatalogWithUsage < Base
+
+    def setup
+      setup_base
+      upload_catalog('Catalog-Mixed-With-Usage.xml', false, @user, @options)
+      @account  = create_account(@user, @options)
+    end
+
+    def teardown
+      teardown_base
+    end
+
+    # Basic test to verify/understand the catalog
+    def test_basic_recurring
+      bp = create_entitlement_from_plan(@account.account_id, nil, 'voip-monthly-unlimited', @user, @options)
+      assert_equal('voip-monthly-unlimited', bp.plan_name)
+      wait_for_expected_clause(1, @account, @options, &@proc_account_invoices_nb)
+
+      # First invoice
+      all_invoices = @account.invoices(true, @options)
+      assert_equal(1, all_invoices.size)
+      sort_invoices!(all_invoices)
+      first_invoice = all_invoices[0]
+      check_invoice_no_balance(first_invoice, 39.99, 'USD', DEFAULT_KB_INIT_DATE)
+      check_invoice_item(first_invoice.items[0], first_invoice.invoice_id, 39.99, 'USD', 'RECURRING', 'voip-monthly-unlimited', 'voip-monthly-unlimited-evergreen', '2013-08-01', '2013-09-01')
+
+      # 2013-09-01
+      kb_clock_add_months(1, nil, @options)
+      wait_for_expected_clause(2, @account, @options, &@proc_account_invoices_nb)
+
+      # Second invoice
+      all_invoices = @account.invoices(true, @options)
+      assert_equal(2, all_invoices.size)
+      sort_invoices!(all_invoices)
+      second_invoice = all_invoices[1]
+      check_invoice_no_balance(second_invoice, 39.99, 'USD', '2013-09-01')
+      check_invoice_item(second_invoice.items[0], second_invoice.invoice_id, 39.99, 'USD', 'RECURRING', 'voip-monthly-unlimited', 'voip-monthly-unlimited-evergreen', '2013-09-01', '2013-10-01')
+
+      # Verify END_OF_TERM cancellation
+      requested_date = nil
+      entitlement_policy = nil
+      billing_policy = nil
+      use_requested_date_for_billing = nil
+      bp.cancel(@user, nil, nil, requested_date, entitlement_policy, billing_policy, use_requested_date_for_billing, @options)
+
+      bp = get_subscription(bp.subscription_id, @options)
+      check_subscription(bp, 'Voip', 'BASE', 'MONTHLY', 'DEFAULT', DEFAULT_KB_INIT_DATE, '2013-09-01', DEFAULT_KB_INIT_DATE, '2013-10-01')
+      assert_equal('CANCELLED', bp.state)
+
+      # 2013-10-01
+      kb_clock_add_months(1, nil, @options)
+
+      # No new invoice is generated
+      all_invoices = @account.invoices(true, @options)
+      assert_equal(2, all_invoices.size)
+    end
+
+    # Basic test to verify/understand the catalog
+    def test_basic_usage
+      bp = create_entitlement_from_plan(@account.account_id, nil, 'voip-monthly-by-usage', @user, @options)
+      assert_equal('voip-monthly-by-usage', bp.plan_name)
+      assert_equal(0, @account.invoices(true, @options).size)
+
+      # 2013-08-01 -> 2013-08-31, record a total of 15 minutes
+      (0..30).each do |day|
+        today = Date.parse('2013-08-01') + day
+        usage_input = [{:unit_type => 'minutes',
+                        :usage_records => [{:record_date => today.to_s, :amount => day % 2}]
+                       }]
+        record_usage(bp.subscription_id, usage_input, @user, @options)
+
+        # Check recorded usage (note that endDate is exclusive in the API)
+        recorded_usage = get_usage_for_subscription(bp.subscription_id, '2013-08-01', (today + 1).to_s, @options)
+        assert_equal(recorded_usage.subscription_id, bp.subscription_id)
+        assert_equal(recorded_usage.start_date, '2013-08-01')
+        assert_equal(recorded_usage.end_date, (today + 1).to_s)
+        assert_equal(recorded_usage.rolled_up_units.size, 1)
+        assert_equal(recorded_usage.rolled_up_units[0].amount, day - day / 2)
+        assert_equal(recorded_usage.rolled_up_units[0].unit_type, 'minutes')
+
+        # No invoice
+        assert_equal(0, @account.invoices(true, @options).size)
+
+        kb_clock_add_days(1, nil, @options)
+      end
+
+      # 2013-09-01
+      wait_for_expected_clause(1, @account, @options, &@proc_account_invoices_nb)
+
+      # First invoice
+      all_invoices = @account.invoices(true, @options)
+      assert_equal(1, all_invoices.size)
+      sort_invoices!(all_invoices)
+      first_invoice = all_invoices[0]
+      check_invoice_no_balance(first_invoice, 14.85, 'USD', '2013-09-01')
+      check_invoice_item(first_invoice.items[0], first_invoice.invoice_id, 14.85, 'USD', 'USAGE', 'voip-monthly-by-usage', 'voip-monthly-by-usage-evergreen', '2013-08-01', '2013-09-01')
+      # AGGREGATE mode by default
+      check_invoice_consumable_item_detail(first_invoice.items[0],
+                                           [{:tier => 1, :unit_type => 'minutes', :unit_qty => 15, :tier_price => 0.99 }], 14.85)
+
+      # 2013-10-01
+      kb_clock_add_months(1, nil, @options)
+
+      # Second invoice: verify month with no usage data
+      all_invoices = @account.invoices(true, @options)
+      assert_equal(2, all_invoices.size)
+      sort_invoices!(all_invoices)
+      second_invoice = all_invoices[1]
+      check_invoice_no_balance(second_invoice, 0, 'USD', '2013-10-01')
+      check_invoice_item(second_invoice.items[0], second_invoice.invoice_id, 0, 'USD', 'USAGE', 'voip-monthly-by-usage', 'voip-monthly-by-usage-evergreen', '2013-09-01', '2013-10-01')
+      # AGGREGATE mode by default
+      check_invoice_consumable_item_detail(second_invoice.items[0],
+                                           [{:tier => 1, :unit_type => 'minutes', :unit_qty => 0, :tier_price => 0.99 }], 0)
+
+      # 2013-10-15
+      kb_clock_add_days(14, nil, @options)
+
+      # Add usage for the month
+      usage_input = [{:unit_type => 'minutes',
+                      :usage_records => [{:record_date => '2013-10-01', :amount => 1},
+                                         {:record_date => '2013-10-02', :amount => 1},
+                                         {:record_date => '2013-10-03', :amount => 1},
+                                         {:record_date => '2013-10-04', :amount => 1},
+                                         {:record_date => '2013-10-05', :amount => 1},
+                                         {:record_date => '2013-10-07', :amount => 1}]
+                     }]
+      record_usage(bp.subscription_id, usage_input, @user, @options)
+
+      # Verify IMMEDIATE cancellation
+      requested_date = nil
+      entitlement_policy = nil
+      billing_policy = nil
+      use_requested_date_for_billing = nil
+      bp.cancel(@user, nil, nil, requested_date, entitlement_policy, billing_policy, use_requested_date_for_billing, @options)
+
+      bp = get_subscription(bp.subscription_id, @options)
+      check_subscription(bp, 'Voip', 'BASE', 'NO_BILLING_PERIOD', 'DEFAULT', DEFAULT_KB_INIT_DATE, '2013-10-15', DEFAULT_KB_INIT_DATE, '2013-10-15')
+      assert_equal('CANCELLED', bp.state)
+
+      wait_for_expected_clause(3, @account, @options, &@proc_account_invoices_nb)
+
+      # Third invoice
+      all_invoices = @account.invoices(true, @options)
+      assert_equal(3, all_invoices.size)
+      sort_invoices!(all_invoices)
+      third_invoice = all_invoices[2]
+      check_invoice_no_balance(third_invoice, 5.94, 'USD', '2013-10-15')
+      check_invoice_item(third_invoice.items[0], third_invoice.invoice_id, 5.94, 'USD', 'USAGE', 'voip-monthly-by-usage', 'voip-monthly-by-usage-evergreen', '2013-10-01', '2013-10-15')
+      # AGGREGATE mode by default
+      check_invoice_consumable_item_detail(third_invoice.items[0],
+                                           [{:tier => 1, :unit_type => 'minutes', :unit_qty => 6, :tier_price => 0.99 }], 5.94)
+
+      # 2013-12-15
+      kb_clock_add_months(2, nil, @options)
+
+      # No new invoice is generated
+      assert_equal(3, @account.invoices(true, @options).size)
+    end
+
+    # Basic test to verify/understand the catalog
+    def test_pause_resume_recurring
+      bp = create_entitlement_from_plan(@account.account_id, nil, 'voip-monthly-unlimited', @user, @options)
+      assert_equal('voip-monthly-unlimited', bp.plan_name)
+      wait_for_expected_clause(1, @account, @options, &@proc_account_invoices_nb)
+
+      # First invoice
+      all_invoices = @account.invoices(true, @options)
+      assert_equal(1, all_invoices.size)
+      sort_invoices!(all_invoices)
+      first_invoice = all_invoices[0]
+      check_invoice_no_balance(first_invoice, 39.99, 'USD', DEFAULT_KB_INIT_DATE)
+      check_invoice_item(first_invoice.items[0], first_invoice.invoice_id, 39.99, 'USD', 'RECURRING', 'voip-monthly-unlimited', 'voip-monthly-unlimited-evergreen', '2013-08-01', '2013-09-01')
+
+      # 2013-08-05: pause entitlement now, billing at CTD (no proration)
+      kb_clock_add_days(4, nil, @options)
+      set_bundle_blocking_state(bp.bundle_id, 'SUSPENDED', 'BillingAdmin', false, false, true, '2013-09-01', @user, @options)
+      set_bundle_blocking_state(bp.bundle_id, 'SUSPENDED', 'EntitlementAdmin', false, true, false, nil, @user, @options)
+
+      # No new invoice
+      assert_equal(1, @account.invoices(true, @options).size)
+
+      # 2013-10-05
+      kb_clock_add_months(2, nil, @options)
+
+      # No new invoice
+      assert_equal(1, @account.invoices(true, @options).size)
+
+      # Resume entitlement now, billing at BCD (no proration)
+      set_bundle_blocking_state(bp.bundle_id, 'UNSUSPENDED', 'EntitlementAdmin', false, false, false, nil, @user, @options)
+      set_bundle_blocking_state(bp.bundle_id, 'UNSUSPENDED', 'BillingAdmin', false, false, false, '2013-10-01', @user, @options)
+
+      wait_for_expected_clause(2, @account, @options, &@proc_account_invoices_nb)
+
+      # Second invoice
+      all_invoices = @account.invoices(true, @options)
+      assert_equal(2, all_invoices.size)
+      sort_invoices!(all_invoices)
+      second_invoice = all_invoices[1]
+      check_invoice_no_balance(second_invoice, 39.99, 'USD', '2013-10-05')
+      check_invoice_item(second_invoice.items[0], second_invoice.invoice_id, 39.99, 'USD', 'RECURRING', 'voip-monthly-unlimited', 'voip-monthly-unlimited-evergreen', '2013-10-01', '2013-11-01')
+
+      # 2013-11-01
+      kb_clock_add_days(27, nil, @options)
+      wait_for_expected_clause(3, @account, @options, &@proc_account_invoices_nb)
+
+      # Third invoice
+      all_invoices = @account.invoices(true, @options)
+      assert_equal(3, all_invoices.size)
+      sort_invoices!(all_invoices)
+      third_invoice = all_invoices[2]
+      check_invoice_no_balance(third_invoice, 39.99, 'USD', '2013-11-01')
+      check_invoice_item(third_invoice.items[0], third_invoice.invoice_id, 39.99, 'USD', 'RECURRING', 'voip-monthly-unlimited', 'voip-monthly-unlimited-evergreen', '2013-11-01', '2013-12-01')
+    end
+
+  end
+
+end

--- a/killbill-integration-tests/resources/Catalog-Mixed-With-Usage.xml
+++ b/killbill-integration-tests/resources/Catalog-Mixed-With-Usage.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<catalog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="CatalogSchema.xsd ">
+    <effectiveDate>2012-01-01T00:00:00+00:00</effectiveDate>
+    <catalogName>MixedWithUsage</catalogName>
+    <currencies>
+        <currency>USD</currency>
+    </currencies>
+    <units>
+        <unit name="minutes"/>
+    </units>
+    <products>
+        <product name="Voip">
+            <category>BASE</category>
+        </product>
+    </products>
+    <rules>
+        <changePolicy>
+            <changePolicyCase>
+                <policy>IMMEDIATE</policy>
+            </changePolicyCase>
+        </changePolicy>
+        <changeAlignment>
+            <changeAlignmentCase>
+                <alignment>START_OF_BUNDLE</alignment>
+            </changeAlignmentCase>
+        </changeAlignment>
+        <cancelPolicy>
+            <cancelPolicyCase>
+                <policy>END_OF_TERM</policy>
+            </cancelPolicyCase>
+        </cancelPolicy>
+        <createAlignment>
+            <createAlignmentCase>
+                <alignment>START_OF_BUNDLE</alignment>
+            </createAlignmentCase>
+        </createAlignment>
+        <billingAlignment>
+            <billingAlignmentCase>
+                <alignment>SUBSCRIPTION</alignment>
+            </billingAlignmentCase>
+        </billingAlignment>
+        <priceList>
+            <priceListCase>
+                <toPriceList>DEFAULT</toPriceList>
+            </priceListCase>
+        </priceList>
+    </rules>
+    <plans>
+        <plan name="voip-monthly-unlimited">
+            <product>Voip</product>
+            <recurringBillingMode>IN_ADVANCE</recurringBillingMode>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                </duration>
+                <recurring>
+                    <billingPeriod>MONTHLY</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>USD</currency>
+                            <value>39.99</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+            </finalPhase>
+        </plan>
+        <plan name="voip-monthly-by-usage">
+            <product>Voip</product>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                </duration>
+                <usages>
+                    <usage name="voip-by-usage-monthly-in-arrear" billingMode="IN_ARREAR" usageType="CONSUMABLE">
+                        <billingPeriod>MONTHLY</billingPeriod>
+                        <tiers>
+                            <tier>
+                                <blocks>
+                                    <tieredBlock>
+                                        <unit>minutes</unit>
+                                        <size>1</size>
+                                        <prices>
+                                            <price>
+                                                <currency>USD</currency>
+                                                <value>0.99</value>
+                                            </price>
+                                        </prices>
+                                        <max>-1</max>
+                                    </tieredBlock>
+                                </blocks>
+                            </tier>
+                        </tiers>
+                    </usage>
+                </usages>
+            </finalPhase>
+        </plan>
+    </plans>
+    <priceLists>
+        <defaultPriceList name="DEFAULT">
+            <plans>
+                <plan>voip-monthly-unlimited</plan>
+                <plan>voip-monthly-by-usage</plan>
+            </plans>
+        </defaultPriceList>
+    </priceLists>
+</catalog>


### PR DESCRIPTION
Initial tests to verify the catalog (which caught a bug with BCD change, see https://github.com/killbill/killbill/pull/1066).

Interesting upgrade/downgrade tests will come next. I'm also looking into CircleCI failures.