### PR TITLE
plugins: pass plugin version when uninstalling plugin

### DIFF
--- a/killbill-integration-tests/plugins/adyen/test_adyen.rb
+++ b/killbill-integration-tests/plugins/adyen/test_adyen.rb
@@ -24,7 +24,7 @@ module KillBillIntegrationTests
     end
 
     def teardown
-      teardown_plugin_base(PLUGIN_KEY)
+      teardown_plugin_base(PLUGIN_KEY, PLUGIN_VERSION)
     end
 
     def test_healthcheck

--- a/killbill-integration-tests/plugins/analytics/test_analytics.rb
+++ b/killbill-integration-tests/plugins/analytics/test_analytics.rb
@@ -29,7 +29,7 @@ module KillBillIntegrationTests
     end
 
     def teardown
-      teardown_plugin_base(PLUGIN_KEY)
+      teardown_plugin_base(PLUGIN_KEY, PLUGIN_VERSION)
     end
 
     def test_healthcheck

--- a/killbill-integration-tests/plugins/avatax/test_avatax.rb
+++ b/killbill-integration-tests/plugins/avatax/test_avatax.rb
@@ -70,7 +70,7 @@ module KillBillIntegrationTests
     end
 
     def teardown
-      teardown_plugin_base(PLUGIN_KEY)
+      teardown_plugin_base(PLUGIN_KEY, PLUGIN_VERSION)
     end
 
     def test_manual_commit

--- a/killbill-integration-tests/plugins/braintree/test_braintree.rb
+++ b/killbill-integration-tests/plugins/braintree/test_braintree.rb
@@ -30,7 +30,7 @@ module KillBillIntegrationTests
     end
 
     def teardown
-      teardown_plugin_base(PLUGIN_KEY)
+      teardown_plugin_base(PLUGIN_KEY, PLUGIN_VERSION)
     end
 
     def test_healthcheck

--- a/killbill-integration-tests/plugins/catalog-test/test_catalog_plugin_test.rb
+++ b/killbill-integration-tests/plugins/catalog-test/test_catalog_plugin_test.rb
@@ -24,7 +24,7 @@ module KillBillIntegrationTests
     end
 
     def teardown
-      teardown_plugin_base(PLUGIN_KEY)
+      teardown_plugin_base(PLUGIN_KEY, PLUGIN_VERSION)
     end
 
     def test_healthcheck

--- a/killbill-integration-tests/plugins/deposit/test_deposit.rb
+++ b/killbill-integration-tests/plugins/deposit/test_deposit.rb
@@ -29,7 +29,7 @@ module KillBillIntegrationTests
     end
 
     def teardown
-      teardown_plugin_base(PLUGIN_KEY)
+      teardown_plugin_base(PLUGIN_KEY, PLUGIN_VERSION)
     end
 
     def test_healthcheck

--- a/killbill-integration-tests/plugins/email-notifications/test_email_notifications.rb
+++ b/killbill-integration-tests/plugins/email-notifications/test_email_notifications.rb
@@ -105,7 +105,7 @@ module KillBillIntegrationTests
     end
 
     def teardown
-      teardown_plugin_base(PLUGIN_KEY)
+      teardown_plugin_base(PLUGIN_KEY, PLUGIN_VERSION)
       @smtp_server&.shutdown_and_wait_for_completion
     end
 

--- a/killbill-integration-tests/plugins/gocardless/test_gocardless.rb
+++ b/killbill-integration-tests/plugins/gocardless/test_gocardless.rb
@@ -28,7 +28,7 @@ module KillBillIntegrationTests
     end
 
     def teardown
-      teardown_plugin_base(PLUGIN_KEY)
+      teardown_plugin_base(PLUGIN_KEY, PLUGIN_VERSION)
     end
 
     def test_healthcheck

--- a/killbill-integration-tests/plugins/invgrp/test_invgrp_demo.rb
+++ b/killbill-integration-tests/plugins/invgrp/test_invgrp_demo.rb
@@ -25,7 +25,7 @@ module KillBillIntegrationTests
     end
 
     def teardown
-      teardown_plugin_base(PLUGIN_KEY)
+      teardown_plugin_base(PLUGIN_KEY, PLUGIN_VERSION)
     end
 
     def test_healthcheck

--- a/killbill-integration-tests/plugins/payment-test/payment_test_base.rb
+++ b/killbill-integration-tests/plugins/payment-test/payment_test_base.rb
@@ -27,7 +27,7 @@ module KillBillIntegrationTests
       body = { 'CONFIGURE_ACTION': 'ACTION_CLEAR' }.to_json
       KillBillClient::API.post(KILLBILL_PAYMENT_TEST_PREFIX + '/configure', body, {}, @options)
 
-      teardown_plugin_base(PLUGIN_KEY)
+      teardown_plugin_base(PLUGIN_KEY, PLUGIN_VERSION)
     end
   end
 end

--- a/killbill-integration-tests/plugins/plugin_base.rb
+++ b/killbill-integration-tests/plugins/plugin_base.rb
@@ -14,9 +14,9 @@ module KillBillIntegrationTests
       end
     end
 
-    def teardown_plugin_base(plugin_key)
+    def teardown_plugin_base(plugin_key, plugin_version)
       prepare_teardown_sequence(plugin_key) do |seq|
-        run_plugin_sequence('stop', plugin_key, nil, [], seq)
+        run_plugin_sequence('stop', plugin_key, plugin_version, [], seq)
       end
       teardown_base
     end

--- a/killbill-integration-tests/plugins/qualpay/test_qualpay.rb
+++ b/killbill-integration-tests/plugins/qualpay/test_qualpay.rb
@@ -28,7 +28,7 @@ module KillBillIntegrationTests
     end
 
     def teardown
-      teardown_plugin_base(PLUGIN_KEY)
+      teardown_plugin_base(PLUGIN_KEY, PLUGIN_VERSION)
     end
 
     def test_healthcheck

--- a/killbill-integration-tests/plugins/stripe/stripe_base.rb
+++ b/killbill-integration-tests/plugins/stripe/stripe_base.rb
@@ -28,7 +28,7 @@ module KillBillIntegrationTests
     end
 
     def teardown
-      teardown_plugin_base(PLUGIN_KEY)
+      teardown_plugin_base(PLUGIN_KEY, PLUGIN_VERSION)
     end
   end
 end

--- a/killbill-integration-tests/plugins/vertex/test_vertex.rb
+++ b/killbill-integration-tests/plugins/vertex/test_vertex.rb
@@ -31,7 +31,7 @@ module KillBillIntegrationTests
     end
 
     def teardown
-      teardown_plugin_base(PLUGIN_KEY)
+      teardown_plugin_base(PLUGIN_KEY, PLUGIN_VERSION)
     end
 
     def test_healthcheck


### PR DESCRIPTION
This is now required by the KPM plugin.